### PR TITLE
Update FanduelBaseballSettings to include UTIL position

### DIFF
--- a/pydfs_lineup_optimizer/sites/fanduel/settings.py
+++ b/pydfs_lineup_optimizer/sites/fanduel/settings.py
@@ -54,14 +54,14 @@ class FanDuelBaseballSettings(FanDuelSettings):
     budget = 35000
     positions = [
         LineupPosition('P', ('P',)),
-        LineupPosition('C', ('C',)),
-        LineupPosition('1B', ('1B',)),
+        LineupPosition('C/1B', ('C', '1B')),
         LineupPosition('2B', ('2B',)),
         LineupPosition('3B', ('3B',)),
         LineupPosition('SS', ('SS',)),
         LineupPosition('OF', ('OF',)),
         LineupPosition('OF', ('OF',)),
         LineupPosition('OF', ('OF',)),
+        LineupPosition('UTIL', ('1B','2B','3B', 'SS','C', 'OF')),
     ]
 
 


### PR DESCRIPTION
FanDuel updated to consolidate catcher and first base and create new position UTIL, which can be any position except for pitchers.  