### PR TITLE
Changed lineup position names for Draftkings NFL Classic

### DIFF
--- a/pydfs_lineup_optimizer/sites/draftkings/classic/settings.py
+++ b/pydfs_lineup_optimizer/sites/draftkings/classic/settings.py
@@ -42,11 +42,11 @@ class DraftKingsFootballSettings(DraftKingsSettings):
     sport = Sport.FOOTBALL
     positions = [
         LineupPosition('QB', ('QB',)),
-        LineupPosition('WR1', ('WR',)),
-        LineupPosition('WR2', ('WR',)),
-        LineupPosition('WR3', ('WR',)),
-        LineupPosition('RB1', ('RB',)),
-        LineupPosition('RB2', ('RB',)),
+        LineupPosition('RB', ('RB',)),
+        LineupPosition('RB', ('RB',)),
+        LineupPosition('WR', ('WR',)),
+        LineupPosition('WR', ('WR',)),
+        LineupPosition('WR', ('WR',)),
         LineupPosition('TE', ('TE',)),
         LineupPosition('FLEX', ('WR', 'RB', 'TE')),
         LineupPosition('DST', ('DST',))


### PR DESCRIPTION
Please consider these changes for the master branch. These changes alter the lineup position names for NFL draftkings classic mode to match the position names on the website. 

Currently, I'm not able to import lineups into draftkings without this naming change. Please let me know if there's existing logic for naming the positions as defined. 