### PR TITLE
jmelowry/add_defender

### DIFF
--- a/pydfs_lineup_optimizer/sites/yahoo/settings.py
+++ b/pydfs_lineup_optimizer/sites/yahoo/settings.py
@@ -51,6 +51,7 @@ class YahooHockeySettings(YahooSettings):
         LineupPosition('W', ('LW', 'RW')),
         LineupPosition('W', ('LW', 'RW')),
         LineupPosition('W', ('LW', 'RW')),
+        LineupPosition('D', ('D', )),
         LineupPosition('D', ('D', ))
     ]
 


### PR DESCRIPTION
Yahoo NHL lineups are being generated with 1 defender, however lines should be composed of `GGCCWWWDD`.

Currently they are composed of `GGCCWWWD`

Here is the yahoo help page for reference: https://sports.yahoo.com/dailyfantasy/help/nhl/rules