### PR TITLE
Add tiers to draftkings football

### DIFF
--- a/pydfs_lineup_optimizer/sites/draftkings/tiers/settings.py
+++ b/pydfs_lineup_optimizer/sites/draftkings/tiers/settings.py
@@ -30,3 +30,8 @@ class DraftKingsTiersBaseballSettings(DraftKingsTiersSettings):
 @SitesRegistry.register_settings
 class DraftKingsTiersHockeySettings(DraftKingsTiersSettings):
     sport = Sport.HOCKEY
+
+
+@SitesRegistry.register_settings
+class DraftKingsTiersFootballSettings(DraftKingsTiersSettings):
+    sport = Sport.FOOTBALL


### PR DESCRIPTION
Any reason this wasn't just enabled? I've enabled this change locally and it seems to work.