### PR TITLE
Trim whitespace from player_id in dk classic lineup importer 

### DIFF
--- a/pydfs_lineup_optimizer/sites/draftkings/classic/importer.py
+++ b/pydfs_lineup_optimizer/sites/draftkings/classic/importer.py
@@ -88,7 +88,7 @@ class DraftKingsCSVImporter(CSVImporter):  # pragma: nocover
                     try:
                         player_data = line[index]
                         player_data = player_data.replace('(LOCKED)', '')  # Remove possible '(LOCKED)' substring
-                        player_id = player_data.split('(')[1][:-1]
+                        player_id = player_data.split('(')[1].strip()[:-1]
                     except IndexError:
                         raise LineupOptimizerIncorrectCSV
                     try:


### PR DESCRIPTION
This seems to happen pretty rarely but every so often it leaves you with an id like `1234)` instead of `1234` and then it can't find the player_id in the players_dict.