### PR TITLE
Lock players into UTIL positions for fanduel single games NBA

### DIFF
--- a/pydfs_lineup_optimizer/sites/fanduel/classic/settings.py
+++ b/pydfs_lineup_optimizer/sites/fanduel/classic/settings.py
@@ -46,7 +46,7 @@ class FanDuelFootballSettings(FanDuelSettings):
         LineupPosition('WR', ('WR', )),
         LineupPosition('TE', ('TE', )),
         LineupPosition('FLEX', ('RB', 'WR', 'TE')),
-        LineupPosition('DEF', ('D', )),
+        LineupPosition('D', ('D', )),
     ]
 
 

--- a/pydfs_lineup_optimizer/sites/fanduel/single_game/settings.py
+++ b/pydfs_lineup_optimizer/sites/fanduel/single_game/settings.py
@@ -38,8 +38,8 @@ class FanDuelSingleGameBasketballSettings(FanDuelSingleGameSettings):
         LineupPosition('MVP', ('MVP', )),
         LineupPosition('STAR', ('STAR', )),
         LineupPosition('PRO', ('PRO', )),
-        LineupPosition('UTIL', ('PG', 'SG', 'SF', 'PF', 'C')),
-        LineupPosition('UTIL', ('PG', 'SG', 'SF', 'PF', 'C')),
+        LineupPosition('UTIL', ('UTIL', 'PG', 'SG', 'SF', 'PF', 'C')),
+        LineupPosition('UTIL', ('UTIL', 'PG', 'SG', 'SF', 'PF', 'C')),
     ]
 
 


### PR DESCRIPTION
#328 

Can't lock a player into UTIL

error message - Position UTIL doesn't exist Available positions are MVP, PRO, STAR, PG, PF, C, SF, SG

Perhaps a better fix is making the lineup position only take the UTIL as is done in mvp and star slots?